### PR TITLE
Select one of the already connected gamepads in `attachListeners()`

### DIFF
--- a/src/js/lib/input/gamepad-input-mgr.js
+++ b/src/js/lib/input/gamepad-input-mgr.js
@@ -61,6 +61,11 @@ class GamepadInputMgr extends InputMgr {
 
   attachListeners() {
     if (this.isListening()) return;
+
+    // Connect to the first of the already connected gamepads, if any.
+    this.handleGamepadDisConnected();
+
+    // Attach listeners to handle future connects and disconnects.
     window.addEventListener('gamepadconnected', this.handleGamepadDisConnected);
     window.addEventListener(
       'gamepaddisconnected',


### PR DESCRIPTION
The previous method relied on the events that are fired when a gamepad is connected. However, if the listeners are attached to late, e.g. due to long loading times, the events might have been fired already and will be missing. The app would not connect to the respective gamepad in this case.

This patch checks for already available gamepads when the listeners are attached.

Note that this PR does not include updated compilation results. Just add them in the merge commit, if needed.